### PR TITLE
✨ Add data augmentation

### DIFF
--- a/tsts/__init__.py
+++ b/tsts/__init__.py
@@ -8,6 +8,7 @@ from . import (
     optimizers,
     solvers,
     thirdparty,
+    transforms,
     utils,
 )
 
@@ -21,5 +22,6 @@ __all__ = [
     "optimizers",
     "solvers",
     "thirdparty",
+    "transforms",
     "utils",
 ]

--- a/tsts/cfg/defaults.py
+++ b/tsts/cfg/defaults.py
@@ -138,6 +138,13 @@ _C.DATASET.BASE_END_INDEX = -1
 # Normalize per dataset differently
 _C.DATASET.NORM_PER_DATASET = False
 
+_C.PIPELINE = CN()
+# List of transforms
+# Each dictionary must contain `name` and `args` pairs
+# Ex: [{"name": "GaussianNoise", "args": {"mean": 0.0, "std": 0.001}}]
+_C.PIPELINE.TRANSFORMS_TRAIN = []
+_C.PIPELINE.TRANSFORMS_VALID = []
+
 _C.X_SCALER = CN()
 # Scaler (for X) name
 _C.X_SCALER.NAME = "StandardScaler"

--- a/tsts/core/__init__.py
+++ b/tsts/core/__init__.py
@@ -12,6 +12,7 @@ from .registry import (
     SCALERS,
     SCHEDULERS,
     TRAINERS,
+    TRANSFORMS,
 )
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
     "SCALERS",
     "SCHEDULERS",
     "TRAINERS",
+    "TRANSFORMS",
 ]

--- a/tsts/core/registry.py
+++ b/tsts/core/registry.py
@@ -13,6 +13,7 @@ __all__ = [
     "SCALERS",
     "SCHEDULERS",
     "TRAINERS",
+    "TRANSFORMS",
 ]
 
 
@@ -60,3 +61,4 @@ OPTIMIZERS = Registry()
 SCALERS = Registry()
 SCHEDULERS = Registry()
 TRAINERS = Registry()
+TRANSFORMS = Registry()

--- a/tsts/datasets/builder.py
+++ b/tsts/datasets/builder.py
@@ -4,6 +4,7 @@ from torch import Tensor
 from tsts.cfg import CfgNode as CN
 from tsts.core import DATASETS
 from tsts.scalers import Scaler
+from tsts.transforms.pipeline import Pipeline
 
 from .dataset import Dataset
 
@@ -17,6 +18,7 @@ def build_dataset(
     image_set: str,
     X_scaler: Scaler,
     y_scaler: Scaler,
+    pipeline: Pipeline,
     cfg: CN,
 ) -> Dataset:
     if image_set == "train":
@@ -31,6 +33,7 @@ def build_dataset(
         image_set,
         X_scaler,
         y_scaler,
+        pipeline,
         cfg,
     )
     return dataset

--- a/tsts/solvers/solver.py
+++ b/tsts/solvers/solver.py
@@ -22,6 +22,8 @@ from tsts.optimizers import build_optimizer
 from tsts.scalers import Scaler
 from tsts.schedulers import Scheduler, build_scheduler
 from tsts.trainers import Trainer, build_trainer
+from tsts.transforms import build_pipeline
+from tsts.transforms.pipeline import Pipeline
 from tsts.types import MaybeRawDataset, RawDataset
 from tsts.utils import set_random_seed
 
@@ -172,6 +174,7 @@ class Solver(object):
         time_stamps: MaybeRawDataset,
         X_scaler: Scaler,
         y_scaler: Scaler,
+        pipeline: Pipeline,
     ) -> Dataset:
         train_datasets = []
         num_datasets = len(X)
@@ -183,6 +186,7 @@ class Solver(object):
                 "train",
                 X_scaler,
                 y_scaler,
+                pipeline,
                 self.cfg,
             )
             train_datasets.append(td)
@@ -196,6 +200,7 @@ class Solver(object):
         time_stamps: MaybeRawDataset,
         X_scaler: Scaler,
         y_scaler: Scaler,
+        pipeline: Pipeline,
     ) -> Dataset:
         valid_datasets = []
         num_datasets = len(X)
@@ -207,6 +212,7 @@ class Solver(object):
                 "valid",
                 X_scaler,
                 y_scaler,
+                pipeline,
                 self.cfg,
             )
             valid_datasets.append(vd)
@@ -216,6 +222,14 @@ class Solver(object):
     def build_collator(self) -> Collator:
         collator = build_collator(self.cfg)
         return collator
+
+    def build_train_pipeline(self) -> Pipeline:
+        train_pipeline = build_pipeline("train", self.cfg)
+        return train_pipeline
+
+    def build_valid_pipeline(self) -> Pipeline:
+        valid_pipeline = build_pipeline("valid", self.cfg)
+        return valid_pipeline
 
     def build_train_dataloader(
         self,

--- a/tsts/transforms/__init__.py
+++ b/tsts/transforms/__init__.py
@@ -1,0 +1,5 @@
+from .builder import build_pipeline
+from .pipeline import Pipeline
+from .transform import Transform
+
+__all__ = ["build_pipeline", "Pipeline", "Transform"]

--- a/tsts/transforms/__init__.py
+++ b/tsts/transforms/__init__.py
@@ -1,5 +1,6 @@
 from .builder import build_pipeline
+from .noise import GaussianNoise
 from .pipeline import Pipeline
 from .transform import Transform
 
-__all__ = ["build_pipeline", "Pipeline", "Transform"]
+__all__ = ["build_pipeline", "GaussianNoise", "Pipeline", "Transform"]

--- a/tsts/transforms/builder.py
+++ b/tsts/transforms/builder.py
@@ -1,0 +1,15 @@
+from tsts.cfg import CfgNode as CN
+from tsts.core import TRANSFORMS
+from tsts.transforms.pipeline import Pipeline
+
+
+def build_pipeline(image_set: str, cfg: CN) -> Pipeline:
+    if image_set == "train":
+        transform_args = cfg.PIPELINE.TRANSFORMS_TRAIN
+    else:
+        transform_args = cfg.PIPELINE.TRANSFORMS_VALID
+    transforms = []
+    for arg in transform_args:
+        transforms.append(TRANSFORMS[arg["name"]](**arg["args"]))
+    pipeline = Pipeline(transforms)
+    return pipeline

--- a/tsts/transforms/noise.py
+++ b/tsts/transforms/noise.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from torch import Tensor
+from torch.autograd import Variable
+from tsts.core import TRANSFORMS
+from tsts.types import Frame
+
+from .transform import Transform
+
+
+@TRANSFORMS.register()
+class GaussianNoise(Transform):
+    """Add gaussian noise to input."""
+
+    def __init__(self, mean: float, std: float) -> None:
+        self.mean = mean
+        self.std = std
+
+    def apply(
+        self,
+        X: Tensor,
+        y: Optional[Tensor] = None,
+        bias: Optional[Tensor] = None,
+        time_stamps: Optional[Tensor] = None,
+    ) -> Frame:
+        data = X.data.new(X.size()).normal_(self.mean, self.std)
+        noise = Variable(data)
+        X = X + noise
+        return (X, y, bias, time_stamps)

--- a/tsts/transforms/pipeline.py
+++ b/tsts/transforms/pipeline.py
@@ -37,5 +37,5 @@ class Pipeline(object):
             Timestamps for each step of input time series
         """
         for t in self.transforms:
-            (X, y, bias, time_stamps, y) = t.apply(X, y, bias, time_stamps)
+            (X, y, bias, time_stamps) = t.apply(X, y, bias, time_stamps)
         return (X, y, bias, time_stamps)

--- a/tsts/transforms/pipeline.py
+++ b/tsts/transforms/pipeline.py
@@ -1,0 +1,41 @@
+from typing import List, Optional
+
+from torch import Tensor
+from tsts.types import Frame
+
+from .transform import Transform
+
+__all__ = ["Pipeline"]
+
+
+class Pipeline(object):
+    def __init__(self, transforms: List[Transform]) -> None:
+        self.transforms = transforms
+
+    @property
+    def num_transforms(self) -> int:
+        return len(self.transforms)
+
+    def apply(
+        self,
+        X: Tensor,
+        y: Optional[Tensor] = None,
+        bias: Optional[Tensor] = None,
+        time_stamps: Optional[Tensor] = None,
+    ) -> Frame:
+        """Apply a series of transforms to given input.
+
+        Parameters
+        ----------
+        X : Tensor
+            Input time series
+
+        y : Optional[Tensor]
+            Ground truth for input time series
+
+        time_stamps : Optional[Tensor]
+            Timestamps for each step of input time series
+        """
+        for t in self.transforms:
+            (X, y, bias, time_stamps, y) = t.apply(X, y, bias, time_stamps)
+        return (X, y, bias, time_stamps)

--- a/tsts/transforms/transform.py
+++ b/tsts/transforms/transform.py
@@ -1,0 +1,21 @@
+import warnings
+from typing import Optional
+
+from torch import Tensor
+from tsts.types import Frame
+
+__all__ = ["Transform"]
+
+
+class Transform(object):
+    """Base transform class."""
+
+    def apply(
+        self,
+        X: Tensor,
+        y: Optional[Tensor] = None,
+        bias: Optional[Tensor] = None,
+        time_stamps: Optional[Tensor] = None,
+    ) -> Frame:
+        warnings.warn("Base transform is called. Be sure your pipeline is correct!")
+        return (X, y, bias, time_stamps)

--- a/tsts/types.py
+++ b/tsts/types.py
@@ -2,7 +2,7 @@ from typing import Callable, List, Optional, Tuple
 
 from torch import Tensor
 
-__all__ = ["Batch", "MaybeRawDataset", "RawBatch", "RawDataset"]
+__all__ = ["Batch", "MaybeRawDataset", "RawBatch", "RawDataset", "Frame"]
 
 
 Batch = Tuple[
@@ -27,3 +27,6 @@ RawBatch = Tuple[
     ]
 ]
 RawDataset = List[Tensor]
+# X, y, bias, time_stamps
+# NOTE: y and time_stamps (& bias) are None during test
+Frame = Tuple[Tensor, Optional[Tensor], Optional[Tensor], Optional[Tensor]]


### PR DESCRIPTION
# About this PR

Added data augmentation feature. Currently, `GaussianNoise` is the only data augmentation.

## Example

Add the following lines to config to use `GaussainNoise` data augmentation which adds gaussian noise to input time series.

```yaml
PIPELINE:
  TRANSFORMS_TRAIN: [{"name": "GaussianNoise", "args": {"mean": 0.0, "std": 1.0}}]
```

Use `TRANSFORMS` registry to define custom data augmentation methods.

```python
from tsts.core import TRANSFORMS
from tsts.transforms.transform import Transform


@TRANSFORMS.register()
class CustomTransform(Transform):

    def apply(self, X, y, bias, time_stamps):
        # Apply data augmentation here
        return (X, y, bias, time_stamps)
```