### PR TITLE
🔧 Fix starting dataset index

### DIFF
--- a/tsts/cfg/defaults.py
+++ b/tsts/cfg/defaults.py
@@ -134,7 +134,7 @@ _C.DATASET.NAME_TRAIN = "Dataset"
 # Validation dataset name
 _C.DATASET.NAME_VALID = "Dataset"
 # Dataset index starts with this value
-_C.DATASET.BASE_START_INDEX = 0
+_C.DATASET.BASE_START_INDEX = 192
 # Last BASE_END_INDEX samples are not used for training
 _C.DATASET.BASE_END_INDEX = -1
 # Normalize per dataset differently


### PR DESCRIPTION
# About this PR

I found `_C.DATASET.BASE_START_INDEX` causes error when its value is 0. So I set it to 192 (2x `_C.IO.LOOKBACK`).